### PR TITLE
Make project runnable with Python backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Molpalata Telegram Mini App
+
+This repository contains a simple implementation of a Telegram Mini App for the youth chamber.
+
+* `backend_py/` – Python backend using only the standard library and SQLite
+* `frontend/` – React frontend served as static HTML
+
+## Running the backend
+
+```bash
+cd backend_py
+python3 app.py
+```
+
+## Running tests
+
+```bash
+cd backend_py
+python3 -m unittest
+```

--- a/backend_node/README.md
+++ b/backend_node/README.md
@@ -1,0 +1,1 @@
+Legacy Node backend (requires npm packages)

--- a/backend_node/__tests__/sample.test.js
+++ b/backend_node/__tests__/sample.test.js
@@ -1,0 +1,4 @@
+const sum = (a, b) => a + b;
+test('adds numbers', () => {
+  expect(sum(1,2)).toBe(3);
+});

--- a/backend_node/package.json
+++ b/backend_node/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest",
+    "start": "node src/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.2",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.0"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/backend_node/src/index.js
+++ b/backend_node/src/index.js
@@ -1,0 +1,121 @@
+const express = require('express');
+const sqlite3 = require('sqlite3').verbose();
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const app = express();
+const db = new sqlite3.Database('./db.sqlite');
+app.use(express.json());
+
+const SECRET = 'secret-key';
+
+// Create tables if not exist
+const userTable = `CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  full_name TEXT,
+  birth_date TEXT,
+  phone TEXT,
+  username TEXT,
+  email TEXT UNIQUE,
+  password TEXT,
+  role TEXT DEFAULT 'candidate',
+  approved INTEGER DEFAULT 0
+)`;
+const eventTable = `CREATE TABLE IF NOT EXISTS events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  title TEXT,
+  datetime TEXT,
+  category TEXT,
+  points INTEGER,
+  description TEXT
+)`;
+const attendanceTable = `CREATE TABLE IF NOT EXISTS attendance (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER,
+  event_id INTEGER,
+  attended INTEGER,
+  FOREIGN KEY(user_id) REFERENCES users(id),
+  FOREIGN KEY(event_id) REFERENCES events(id)
+)`;
+
+db.serialize(() => {
+  db.run(userTable);
+  db.run(eventTable);
+  db.run(attendanceTable);
+});
+
+function authMiddleware(req, res, next) {
+  const token = req.headers['authorization'];
+  if (!token) return res.status(401).json({ error: 'No token' });
+  jwt.verify(token.split(' ')[1], SECRET, (err, decoded) => {
+    if (err) return res.status(403).json({ error: 'Invalid token' });
+    req.user = decoded;
+    next();
+  });
+}
+
+app.post('/api/auth/register', (req, res) => {
+  const { full_name, birth_date, phone, username, email, password } = req.body;
+  const hash = bcrypt.hashSync(password, 10);
+  const stmt = db.prepare('INSERT INTO users (full_name, birth_date, phone, username, email, password) VALUES (?, ?, ?, ?, ?, ?)');
+  stmt.run(full_name, birth_date, phone, username, email, hash, function(err) {
+    if (err) return res.status(400).json({ error: err.message });
+    res.json({ id: this.lastID });
+  });
+});
+
+app.post('/api/auth/login', (req, res) => {
+  const { email, password } = req.body;
+  db.get('SELECT * FROM users WHERE email = ?', [email], (err, user) => {
+    if (err || !user) return res.status(400).json({ error: 'User not found' });
+    if (!bcrypt.compareSync(password, user.password)) return res.status(400).json({ error: 'Invalid password' });
+    const token = jwt.sign({ id: user.id, role: user.role }, SECRET);
+    res.json({ token });
+  });
+});
+
+app.get('/api/events', authMiddleware, (req, res) => {
+  db.all('SELECT * FROM events', (err, rows) => {
+    if (err) return res.status(400).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+app.post('/api/events', authMiddleware, (req, res) => {
+  if (req.user.role !== 'admin' && req.user.role !== 'chairman') return res.status(403).json({ error: 'Forbidden' });
+  const { title, datetime, category, points, description } = req.body;
+  const stmt = db.prepare('INSERT INTO events (title, datetime, category, points, description) VALUES (?, ?, ?, ?, ?)');
+  stmt.run(title, datetime, category, points, description, function(err) {
+    if (err) return res.status(400).json({ error: err.message });
+    res.json({ id: this.lastID });
+  });
+});
+
+app.post('/api/attendance', authMiddleware, (req, res) => {
+  const { event_id, attended } = req.body;
+  const stmt = db.prepare('INSERT OR REPLACE INTO attendance (user_id, event_id, attended) VALUES (?, ?, ?)');
+  stmt.run(req.user.id, event_id, attended ? 1 : 0, function(err) {
+    if (err) return res.status(400).json({ error: err.message });
+    res.json({ id: this.lastID });
+  });
+});
+
+app.get('/api/users', authMiddleware, (req, res) => {
+  if (req.user.role !== 'admin' && req.user.role !== 'chairman') return res.status(403).json({ error: 'Forbidden' });
+  db.all('SELECT id, full_name, username, email, role, approved FROM users', (err, rows) => {
+    if (err) return res.status(400).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+app.post('/api/roles/:id', authMiddleware, (req, res) => {
+  if (req.user.role !== 'admin' && req.user.role !== 'chairman') return res.status(403).json({ error: 'Forbidden' });
+  const { role, approved } = req.body;
+  const stmt = db.prepare('UPDATE users SET role = COALESCE(?, role), approved = COALESCE(?, approved) WHERE id = ?');
+  stmt.run(role, approved, req.params.id, function(err) {
+    if (err) return res.status(400).json({ error: err.message });
+    res.json({ updated: this.changes });
+  });
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/backend_py/README.md
+++ b/backend_py/README.md
@@ -1,0 +1,17 @@
+# Backend (Python)
+
+This backend is implemented using only the Python standard library. It stores data in a local SQLite database (`db.sqlite`).
+
+## Development
+
+```bash
+python3 app.py
+```
+
+This will start the server on port 3001.
+
+Run tests with:
+
+```bash
+python3 -m unittest
+```

--- a/backend_py/app.py
+++ b/backend_py/app.py
@@ -1,0 +1,193 @@
+import json
+import sqlite3
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+import uuid
+import hashlib
+
+DB_PATH = 'db.sqlite'
+
+conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+conn.row_factory = sqlite3.Row
+cur = conn.cursor()
+
+# Create tables
+cur.execute('''CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  full_name TEXT,
+  birth_date TEXT,
+  phone TEXT,
+  username TEXT,
+  email TEXT UNIQUE,
+  password TEXT,
+  role TEXT DEFAULT 'candidate',
+  approved INTEGER DEFAULT 0
+)''')
+cur.execute('''CREATE TABLE IF NOT EXISTS events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  title TEXT,
+  datetime TEXT,
+  category TEXT,
+  points INTEGER,
+  description TEXT
+)''')
+cur.execute('''CREATE TABLE IF NOT EXISTS attendance (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER,
+  event_id INTEGER,
+  attended INTEGER,
+  UNIQUE(user_id, event_id)
+)''')
+cur.execute('''CREATE TABLE IF NOT EXISTS tokens (
+  token TEXT PRIMARY KEY,
+  user_id INTEGER
+)''')
+conn.commit()
+
+
+def hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+def create_token(user_id: int) -> str:
+    token = uuid.uuid4().hex
+    cur.execute('INSERT INTO tokens(token, user_id) VALUES (?, ?)', (token, user_id))
+    conn.commit()
+    return token
+
+
+def get_user_by_token(token: str):
+    row = cur.execute('SELECT user_id FROM tokens WHERE token=?', (token,)).fetchone()
+    if not row:
+        return None
+    user = cur.execute('SELECT * FROM users WHERE id=?', (row['user_id'],)).fetchone()
+    return user
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send_json(self, data, status=200):
+        body = json.dumps(data).encode()
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(length).decode()
+        try:
+            data = json.loads(body) if body else {}
+        except json.JSONDecodeError:
+            self._send_json({'error': 'invalid json'}, status=400)
+            return
+        path = urlparse(self.path).path
+
+        if path == '/api/auth/register':
+            self.handle_register(data)
+        elif path == '/api/auth/login':
+            self.handle_login(data)
+        elif path == '/api/events':
+            self.handle_create_event(data)
+        elif path == '/api/attendance':
+            self.handle_attendance(data)
+        elif path.startswith('/api/roles/'):
+            user_id = path.split('/')[-1]
+            self.handle_role_update(user_id, data)
+        else:
+            self._send_json({'error': 'not found'}, status=404)
+
+    def do_GET(self):
+        path = urlparse(self.path).path
+        if path == '/api/events':
+            self.handle_get_events()
+        elif path == '/api/users':
+            self.handle_get_users()
+        else:
+            self._send_json({'error': 'not found'}, status=404)
+
+    # Handlers
+    def handle_register(self, data):
+        try:
+            cur.execute('INSERT INTO users(full_name, birth_date, phone, username, email, password) VALUES (?, ?, ?, ?, ?, ?)',
+                        (data['full_name'], data['birth_date'], data['phone'], data.get('username'), data['email'], hash_password(data['password'])))
+            conn.commit()
+            self._send_json({'status': 'ok'})
+        except Exception as e:
+            self._send_json({'error': str(e)}, status=400)
+
+    def handle_login(self, data):
+        user = cur.execute('SELECT * FROM users WHERE email=?', (data['email'],)).fetchone()
+        if not user or hash_password(data['password']) != user['password']:
+            self._send_json({'error': 'invalid credentials'}, status=400)
+            return
+        token = create_token(user['id'])
+        self._send_json({'token': token})
+
+    def auth_user(self):
+        header = self.headers.get('Authorization', '')
+        if header.startswith('Bearer '):
+            token = header.split(' ')[1]
+            return get_user_by_token(token)
+        return None
+
+    def handle_get_events(self):
+        user = self.auth_user()
+        if not user:
+            self._send_json({'error': 'unauthorized'}, status=401)
+            return
+        rows = cur.execute('SELECT * FROM events').fetchall()
+        events = [dict(row) for row in rows]
+        self._send_json(events)
+
+    def handle_create_event(self, data):
+        user = self.auth_user()
+        if not user or user['role'] not in ('admin', 'chairman'):
+            self._send_json({'error': 'forbidden'}, status=403)
+            return
+        cur.execute('INSERT INTO events(title, datetime, category, points, description) VALUES (?, ?, ?, ?, ?)',
+                    (data['title'], data['datetime'], data['category'], data['points'], data.get('description')))
+        conn.commit()
+        self._send_json({'status': 'created'})
+
+    def handle_attendance(self, data):
+        user = self.auth_user()
+        if not user:
+            self._send_json({'error': 'unauthorized'}, status=401)
+            return
+        try:
+            cur.execute('INSERT OR REPLACE INTO attendance(user_id, event_id, attended) VALUES (?, ?, ?)',
+                        (user['id'], data['event_id'], int(bool(data.get('attended')))))
+            conn.commit()
+            self._send_json({'status': 'saved'})
+        except Exception as e:
+            self._send_json({'error': str(e)}, status=400)
+
+    def handle_get_users(self):
+        user = self.auth_user()
+        if not user or user['role'] not in ('admin', 'chairman'):
+            self._send_json({'error': 'forbidden'}, status=403)
+            return
+        rows = cur.execute('SELECT id, full_name, username, email, role, approved FROM users').fetchall()
+        self._send_json([dict(r) for r in rows])
+
+    def handle_role_update(self, user_id, data):
+        user = self.auth_user()
+        if not user or user['role'] not in ('admin', 'chairman'):
+            self._send_json({'error': 'forbidden'}, status=403)
+            return
+        cur.execute('UPDATE users SET role = COALESCE(?, role), approved = COALESCE(?, approved) WHERE id = ?',
+                    (data.get('role'), data.get('approved'), user_id))
+        conn.commit()
+        self._send_json({'status': 'updated'})
+
+
+if __name__ == '__main__':
+    server = HTTPServer(('0.0.0.0', 3001), Handler)
+    print('Server running on port 3001')
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()

--- a/backend_py/tests/test_basic.py
+++ b/backend_py/tests/test_basic.py
@@ -1,0 +1,57 @@
+import unittest
+import json
+from http.client import HTTPConnection
+import threading
+import os
+import importlib
+
+app = None
+
+class ServerThread(threading.Thread):
+    def run(self):
+        self.httpd = app.HTTPServer(('localhost', 3001), app.Handler)
+        self.httpd.serve_forever()
+
+    def stop(self):
+        self.httpd.shutdown()
+
+class BackendTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        global app
+        if os.path.exists('db.sqlite'):
+            os.remove('db.sqlite')
+        app = importlib.import_module('app')
+        cls.server = ServerThread()
+        cls.server.daemon = True
+        cls.server.start()
+        import time
+        time.sleep(0.5)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.stop()
+
+    def test_register_and_login(self):
+        conn = HTTPConnection('localhost', 3001)
+        user = {
+            'full_name': 'Test User',
+            'birth_date': '2000-01-01',
+            'phone': '123',
+            'username': 'test',
+            'email': 'test@example.com',
+            'password': 'pass'
+        }
+        body = json.dumps(user)
+        conn.request('POST', '/api/auth/register', body, {'Content-Type': 'application/json'})
+        res = conn.getresponse()
+        self.assertEqual(res.status, 200)
+        conn.request('POST', '/api/auth/login', json.dumps({'email': user['email'], 'password': user['password']}), {'Content-Type': 'application/json'})
+        res = conn.getresponse()
+        self.assertEqual(res.status, 200)
+        data = json.loads(res.read())
+        self.assertIn('token', data)
+        conn.close()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,3 @@
+# Frontend
+
+Simple React interface loaded via CDN for the Telegram Mini App. Open `index.html` in a Telegram WebView.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Molpalata Mini App</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+  <div id="root"></div>
+  <script type="text/babel">
+    function App() {
+      const [events, setEvents] = React.useState([]);
+      const tg = window.Telegram.WebApp;
+      React.useEffect(() => {
+        fetch('/api/events', { headers: { 'Authorization': localStorage.getItem('token') }})
+          .then(r => r.json()).then(setEvents);
+      }, []);
+      return (
+        <div>
+          <h1 className="text-xl font-bold mb-4">Мероприятия</h1>
+          <ul>
+            {events.map(e => <li key={e.id} className="mb-2">{e.title} - {e.datetime}</li>)}
+          </ul>
+        </div>
+      );
+    }
+    ReactDOM.render(<App />, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "molpalata",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- switch to a Python backend using SQLite from the standard library
- include simple REST API and accompanying unittest
- document how to run the backend and tests
- keep legacy Node backend under `backend_node/`

## Testing
- `python3 -m unittest discover -s backend_py/tests -v`


------
https://chatgpt.com/codex/tasks/task_e_6846f178425c8332b5a5583212b83e6a