### PR TITLE
Add registration UI and default event points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Сайт Молодёжной палаты района Некрасовка
+
+Простой пример сайта для палаты. Реализована регистрация, вход и просмотр мероприятий.
+
+* `backend_py/` – Python backend using only the standard library and SQLite
+* `backend_node/` – optional Node.js backend
+* `frontend/` – React frontend served as static HTML
+
+## Running the backend
+
+```bash
+cd backend_py
+python3 app.py
+```
+
+После запуска сервер будет доступен на `http://localhost:3001/` и отдаст страницу `frontend/index.html`.
+
+На сайте можно зарегистрироваться или войти в систему. Регистрация требует ФИО, дату рождения, телефон, Telegram username, e‑mail и пароль.
+
+Пример регистрации через curl:
+
+```bash
+curl -X POST http://localhost:3001/api/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"full_name":"Test","birth_date":"2000-01-01","phone":"123","email":"test@example.com","password":"pass"}'
+```
+
+Then log in using the same email and password. After successful login you will see the list of events.
+
+При создании мероприятия баллы назначаются автоматически в зависимости от категории (например, "meeting" = 10, "social_action" = 6).
+
+### Node.js backend (optional)
+
+Alternatively you can run the Node.js version of the backend:
+
+```bash
+cd backend_node
+npm install   # only needed the first time
+npm start
+```
+
+It serves the same frontend on `http://localhost:3001/`.
+
+## Running tests
+
+```bash
+cd backend_py
+python3 -m unittest discover -s tests -v
+```

--- a/backend_node/README.md
+++ b/backend_node/README.md
@@ -1,0 +1,13 @@
+# Node.js Backend
+
+This folder contains an Express implementation of the API. It mirrors the Python backend but requires installing npm dependencies.
+
+## Usage
+
+```bash
+cd backend_node
+npm install  # run once
+npm start
+```
+
+The server listens on port 3001 and serves the React frontend from the `frontend/` directory.

--- a/backend_node/__tests__/sample.test.js
+++ b/backend_node/__tests__/sample.test.js
@@ -1,0 +1,4 @@
+const sum = (a, b) => a + b;
+test('adds numbers', () => {
+  expect(sum(1,2)).toBe(3);
+});

--- a/backend_node/package.json
+++ b/backend_node/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest",
+    "start": "node src/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.2",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.0"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/backend_node/src/index.js
+++ b/backend_node/src/index.js
@@ -1,0 +1,126 @@
+const express = require('express');
+const sqlite3 = require('sqlite3').verbose();
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const path = require('path');
+const app = express();
+const db = new sqlite3.Database('./db.sqlite');
+app.use(express.json());
+app.use(express.static(path.join(__dirname, '..', '..', 'frontend')));
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, '..', '..', 'frontend', 'index.html'));
+});
+
+const SECRET = 'secret-key';
+
+// Create tables if not exist
+const userTable = `CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  full_name TEXT,
+  birth_date TEXT,
+  phone TEXT,
+  username TEXT,
+  email TEXT UNIQUE,
+  password TEXT,
+  role TEXT DEFAULT 'candidate',
+  approved INTEGER DEFAULT 0
+)`;
+const eventTable = `CREATE TABLE IF NOT EXISTS events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  title TEXT,
+  datetime TEXT,
+  category TEXT,
+  points INTEGER,
+  description TEXT
+)`;
+const attendanceTable = `CREATE TABLE IF NOT EXISTS attendance (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER,
+  event_id INTEGER,
+  attended INTEGER,
+  FOREIGN KEY(user_id) REFERENCES users(id),
+  FOREIGN KEY(event_id) REFERENCES events(id)
+)`;
+
+db.serialize(() => {
+  db.run(userTable);
+  db.run(eventTable);
+  db.run(attendanceTable);
+});
+
+function authMiddleware(req, res, next) {
+  const token = req.headers['authorization'];
+  if (!token) return res.status(401).json({ error: 'No token' });
+  jwt.verify(token.split(' ')[1], SECRET, (err, decoded) => {
+    if (err) return res.status(403).json({ error: 'Invalid token' });
+    req.user = decoded;
+    next();
+  });
+}
+
+app.post('/api/auth/register', (req, res) => {
+  const { full_name, birth_date, phone, username, email, password } = req.body;
+  const hash = bcrypt.hashSync(password, 10);
+  const stmt = db.prepare('INSERT INTO users (full_name, birth_date, phone, username, email, password) VALUES (?, ?, ?, ?, ?, ?)');
+  stmt.run(full_name, birth_date, phone, username, email, hash, function(err) {
+    if (err) return res.status(400).json({ error: err.message });
+    res.json({ id: this.lastID });
+  });
+});
+
+app.post('/api/auth/login', (req, res) => {
+  const { email, password } = req.body;
+  db.get('SELECT * FROM users WHERE email = ?', [email], (err, user) => {
+    if (err || !user) return res.status(400).json({ error: 'User not found' });
+    if (!bcrypt.compareSync(password, user.password)) return res.status(400).json({ error: 'Invalid password' });
+    const token = jwt.sign({ id: user.id, role: user.role }, SECRET);
+    res.json({ token });
+  });
+});
+
+app.get('/api/events', authMiddleware, (req, res) => {
+  db.all('SELECT * FROM events', (err, rows) => {
+    if (err) return res.status(400).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+app.post('/api/events', authMiddleware, (req, res) => {
+  if (req.user.role !== 'admin' && req.user.role !== 'chairman') return res.status(403).json({ error: 'Forbidden' });
+  const { title, datetime, category, points, description } = req.body;
+  const stmt = db.prepare('INSERT INTO events (title, datetime, category, points, description) VALUES (?, ?, ?, ?, ?)');
+  stmt.run(title, datetime, category, points, description, function(err) {
+    if (err) return res.status(400).json({ error: err.message });
+    res.json({ id: this.lastID });
+  });
+});
+
+app.post('/api/attendance', authMiddleware, (req, res) => {
+  const { event_id, attended } = req.body;
+  const stmt = db.prepare('INSERT OR REPLACE INTO attendance (user_id, event_id, attended) VALUES (?, ?, ?)');
+  stmt.run(req.user.id, event_id, attended ? 1 : 0, function(err) {
+    if (err) return res.status(400).json({ error: err.message });
+    res.json({ id: this.lastID });
+  });
+});
+
+app.get('/api/users', authMiddleware, (req, res) => {
+  if (req.user.role !== 'admin' && req.user.role !== 'chairman') return res.status(403).json({ error: 'Forbidden' });
+  db.all('SELECT id, full_name, username, email, role, approved FROM users', (err, rows) => {
+    if (err) return res.status(400).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+app.post('/api/roles/:id', authMiddleware, (req, res) => {
+  if (req.user.role !== 'admin' && req.user.role !== 'chairman') return res.status(403).json({ error: 'Forbidden' });
+  const { role, approved } = req.body;
+  const stmt = db.prepare('UPDATE users SET role = COALESCE(?, role), approved = COALESCE(?, approved) WHERE id = ?');
+  stmt.run(role, approved, req.params.id, function(err) {
+    if (err) return res.status(400).json({ error: err.message });
+    res.json({ updated: this.changes });
+  });
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/backend_py/README.md
+++ b/backend_py/README.md
@@ -1,0 +1,17 @@
+# Backend (Python)
+
+This backend is implemented using only the Python standard library. It stores data in a local SQLite database (`db.sqlite`).
+
+## Development
+
+```bash
+python3 app.py
+```
+
+This will start the server on port 3001.
+
+Run tests with:
+
+```bash
+python3 -m unittest
+```

--- a/backend_py/app.py
+++ b/backend_py/app.py
@@ -1,0 +1,218 @@
+import json
+import sqlite3
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+import uuid
+import hashlib
+import os
+
+DB_PATH = 'db.sqlite'
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+INDEX_PATH = os.path.join(BASE_DIR, '..', 'frontend', 'index.html')
+
+conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+conn.row_factory = sqlite3.Row
+cur = conn.cursor()
+
+# Create tables
+cur.execute('''CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  full_name TEXT,
+  birth_date TEXT,
+  phone TEXT,
+  username TEXT,
+  email TEXT UNIQUE,
+  password TEXT,
+  role TEXT DEFAULT 'candidate',
+  approved INTEGER DEFAULT 0
+)''')
+cur.execute('''CREATE TABLE IF NOT EXISTS events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  title TEXT,
+  datetime TEXT,
+  category TEXT,
+  points INTEGER,
+  description TEXT
+)''')
+cur.execute('''CREATE TABLE IF NOT EXISTS attendance (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER,
+  event_id INTEGER,
+  attended INTEGER,
+  UNIQUE(user_id, event_id)
+)''')
+cur.execute('''CREATE TABLE IF NOT EXISTS tokens (
+  token TEXT PRIMARY KEY,
+  user_id INTEGER
+)''')
+conn.commit()
+
+# Default points for event categories
+CATEGORY_POINTS = {
+    'meeting': 10,
+    'social_action': 6,
+    'social_action_video': 10,
+    'own_event': 16,
+}
+
+
+def hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+def create_token(user_id: int) -> str:
+    token = uuid.uuid4().hex
+    cur.execute('INSERT INTO tokens(token, user_id) VALUES (?, ?)', (token, user_id))
+    conn.commit()
+    return token
+
+
+def get_user_by_token(token: str):
+    row = cur.execute('SELECT user_id FROM tokens WHERE token=?', (token,)).fetchone()
+    if not row:
+        return None
+    user = cur.execute('SELECT * FROM users WHERE id=?', (row['user_id'],)).fetchone()
+    return user
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send_json(self, data, status=200):
+        body = json.dumps(data).encode()
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(length).decode()
+        try:
+            data = json.loads(body) if body else {}
+        except json.JSONDecodeError:
+            self._send_json({'error': 'invalid json'}, status=400)
+            return
+        path = urlparse(self.path).path
+
+        if path == '/api/auth/register':
+            self.handle_register(data)
+        elif path == '/api/auth/login':
+            self.handle_login(data)
+        elif path == '/api/events':
+            self.handle_create_event(data)
+        elif path == '/api/attendance':
+            self.handle_attendance(data)
+        elif path.startswith('/api/roles/'):
+            user_id = path.split('/')[-1]
+            self.handle_role_update(user_id, data)
+        else:
+            self._send_json({'error': 'not found'}, status=404)
+
+    def do_GET(self):
+        path = urlparse(self.path).path
+        if path in ('/', '/index.html'):
+            try:
+                with open(INDEX_PATH, 'rb') as f:
+                    body = f.read()
+                self.send_response(200)
+                self.send_header('Content-Type', 'text/html')
+                self.send_header('Content-Length', str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            except FileNotFoundError:
+                self._send_json({'error': 'not found'}, status=404)
+        elif path == '/api/events':
+            self.handle_get_events()
+        elif path == '/api/users':
+            self.handle_get_users()
+        else:
+            self._send_json({'error': 'not found'}, status=404)
+
+    # Handlers
+    def handle_register(self, data):
+        try:
+            cur.execute('INSERT INTO users(full_name, birth_date, phone, username, email, password) VALUES (?, ?, ?, ?, ?, ?)',
+                        (data['full_name'], data['birth_date'], data['phone'], data.get('username'), data['email'], hash_password(data['password'])))
+            conn.commit()
+            self._send_json({'status': 'ok'})
+        except Exception as e:
+            self._send_json({'error': str(e)}, status=400)
+
+    def handle_login(self, data):
+        user = cur.execute('SELECT * FROM users WHERE email=?', (data['email'],)).fetchone()
+        if not user or hash_password(data['password']) != user['password']:
+            self._send_json({'error': 'invalid credentials'}, status=400)
+            return
+        token = create_token(user['id'])
+        self._send_json({'token': token})
+
+    def auth_user(self):
+        header = self.headers.get('Authorization', '')
+        if header.startswith('Bearer '):
+            token = header.split(' ')[1]
+            return get_user_by_token(token)
+        return None
+
+    def handle_get_events(self):
+        user = self.auth_user()
+        if not user:
+            self._send_json({'error': 'unauthorized'}, status=401)
+            return
+        rows = cur.execute('SELECT * FROM events').fetchall()
+        events = [dict(row) for row in rows]
+        self._send_json(events)
+
+    def handle_create_event(self, data):
+        user = self.auth_user()
+        if not user or user['role'] not in ('admin', 'chairman'):
+            self._send_json({'error': 'forbidden'}, status=403)
+            return
+        points = data.get('points')
+        if points is None:
+            points = CATEGORY_POINTS.get(data['category'], 0)
+        cur.execute('INSERT INTO events(title, datetime, category, points, description) VALUES (?, ?, ?, ?, ?)',
+                    (data['title'], data['datetime'], data['category'], points, data.get('description')))
+        conn.commit()
+        self._send_json({'status': 'created'})
+
+    def handle_attendance(self, data):
+        user = self.auth_user()
+        if not user:
+            self._send_json({'error': 'unauthorized'}, status=401)
+            return
+        try:
+            cur.execute('INSERT OR REPLACE INTO attendance(user_id, event_id, attended) VALUES (?, ?, ?)',
+                        (user['id'], data['event_id'], int(bool(data.get('attended')))))
+            conn.commit()
+            self._send_json({'status': 'saved'})
+        except Exception as e:
+            self._send_json({'error': str(e)}, status=400)
+
+    def handle_get_users(self):
+        user = self.auth_user()
+        if not user or user['role'] not in ('admin', 'chairman'):
+            self._send_json({'error': 'forbidden'}, status=403)
+            return
+        rows = cur.execute('SELECT id, full_name, username, email, role, approved FROM users').fetchall()
+        self._send_json([dict(r) for r in rows])
+
+    def handle_role_update(self, user_id, data):
+        user = self.auth_user()
+        if not user or user['role'] not in ('admin', 'chairman'):
+            self._send_json({'error': 'forbidden'}, status=403)
+            return
+        cur.execute('UPDATE users SET role = COALESCE(?, role), approved = COALESCE(?, approved) WHERE id = ?',
+                    (data.get('role'), data.get('approved'), user_id))
+        conn.commit()
+        self._send_json({'status': 'updated'})
+
+
+if __name__ == '__main__':
+    server = HTTPServer(('0.0.0.0', 3001), Handler)
+    print('Server running on port 3001')
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()

--- a/backend_py/tests/test_basic.py
+++ b/backend_py/tests/test_basic.py
@@ -1,0 +1,84 @@
+import unittest
+import json
+from http.client import HTTPConnection
+import threading
+import os
+import importlib
+
+app = None
+
+class ServerThread(threading.Thread):
+    def run(self):
+        self.httpd = app.HTTPServer(('localhost', 3001), app.Handler)
+        self.httpd.serve_forever()
+
+    def stop(self):
+        self.httpd.shutdown()
+
+class BackendTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        global app
+        if os.path.exists('db.sqlite'):
+            os.remove('db.sqlite')
+        app = importlib.import_module('app')
+        cls.server = ServerThread()
+        cls.server.daemon = True
+        cls.server.start()
+        import time
+        time.sleep(0.5)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.stop()
+
+    def test_register_and_login(self):
+        conn = HTTPConnection('localhost', 3001)
+        user = {
+            'full_name': 'Test User',
+            'birth_date': '2000-01-01',
+            'phone': '123',
+            'username': 'test',
+            'email': 'test@example.com',
+            'password': 'pass'
+        }
+        body = json.dumps(user)
+        conn.request('POST', '/api/auth/register', body, {'Content-Type': 'application/json'})
+        res = conn.getresponse()
+        self.assertEqual(res.status, 200)
+        conn.request('POST', '/api/auth/login', json.dumps({'email': user['email'], 'password': user['password']}), {'Content-Type': 'application/json'})
+        res = conn.getresponse()
+        self.assertEqual(res.status, 200)
+        data = json.loads(res.read())
+        self.assertIn('token', data)
+        token = data['token']
+        # promote to admin directly in DB
+        import sqlite3
+        db = sqlite3.connect('db.sqlite')
+        db.execute("UPDATE users SET role='admin' WHERE email=?", (user['email'],))
+        db.commit()
+        db.close()
+
+        # create event without specifying points
+        event = {
+            'title': 'Meeting',
+            'datetime': '2025-01-01 10:00',
+            'category': 'meeting',
+            'description': 'First meeting'
+        }
+        headers = {
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {token}'
+        }
+        conn.request('POST', '/api/events', json.dumps(event), headers)
+        res = conn.getresponse()
+        self.assertEqual(res.status, 200)
+        conn.request('GET', '/api/events', headers=headers)
+        res = conn.getresponse()
+        self.assertEqual(res.status, 200)
+        events = json.loads(res.read())
+        self.assertEqual(events[0]['points'], 10)
+        conn.close()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,3 @@
+# Frontend
+
+Simple React interface loaded via CDN. Open `index.html` in your browser.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Молодёжная палата Некрасовки</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+  <div id="root"></div>
+  <script type="text/babel">
+    function App() {
+      const [token, setToken] = React.useState(localStorage.getItem('token'));
+      const [events, setEvents] = React.useState([]);
+      const [email, setEmail] = React.useState('');
+      const [password, setPassword] = React.useState('');
+      const [showReg, setShowReg] = React.useState(false);
+      const [fullName, setFullName] = React.useState('');
+      const [birthDate, setBirthDate] = React.useState('');
+      const [phone, setPhone] = React.useState('');
+      const [username, setUsername] = React.useState('');
+      const [regEmail, setRegEmail] = React.useState('');
+      const [regPassword, setRegPassword] = React.useState('');
+
+      React.useEffect(() => {
+        if (!token) return;
+        fetch('/api/events', { headers: { 'Authorization': 'Bearer ' + token }})
+          .then(r => r.json())
+          .then(data => {
+            if (data.error) {
+              console.error(data.error);
+            } else {
+              setEvents(data);
+            }
+          });
+      }, [token]);
+
+      const login = () => {
+        fetch('/api/auth/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password })
+        })
+          .then(r => r.json())
+          .then(data => {
+            if (data.token) {
+              localStorage.setItem('token', data.token);
+              setToken(data.token);
+            } else {
+              alert('Login failed');
+            }
+          });
+      };
+
+      const register = () => {
+        fetch('/api/auth/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            full_name: fullName,
+            birth_date: birthDate,
+            phone,
+            username,
+            email: regEmail,
+            password: regPassword
+          })
+        })
+          .then(r => r.json())
+          .then(data => {
+            if (data.status === 'ok') {
+              alert('Регистрация успешно отправлена');
+              setShowReg(false);
+            } else {
+              alert(data.error || 'Ошибка регистрации');
+            }
+          });
+      };
+
+      const logout = () => {
+        localStorage.removeItem('token');
+        setToken(null);
+        setEvents([]);
+      };
+
+      if (!token) {
+        if (showReg) {
+          return (
+            <div className="space-y-2">
+              <h1 className="text-xl font-bold">Регистрация</h1>
+              <input className="border p-1 w-full" placeholder="ФИО" value={fullName} onChange={e => setFullName(e.target.value)} />
+              <input className="border p-1 w-full" placeholder="Дата рождения" type="date" value={birthDate} onChange={e => setBirthDate(e.target.value)} />
+              <input className="border p-1 w-full" placeholder="Телефон" value={phone} onChange={e => setPhone(e.target.value)} />
+              <input className="border p-1 w-full" placeholder="Telegram username" value={username} onChange={e => setUsername(e.target.value)} />
+              <input className="border p-1 w-full" placeholder="Email" value={regEmail} onChange={e => setRegEmail(e.target.value)} />
+              <input className="border p-1 w-full" placeholder="Пароль" type="password" value={regPassword} onChange={e => setRegPassword(e.target.value)} />
+              <div className="space-x-2">
+                <button className="bg-blue-500 text-white px-3 py-1" onClick={register}>Зарегистрироваться</button>
+                <button className="text-sm" onClick={() => setShowReg(false)}>У меня есть аккаунт</button>
+              </div>
+            </div>
+          );
+        }
+        return (
+          <div className="space-y-2">
+            <h1 className="text-xl font-bold">Вход</h1>
+            <input className="border p-1 w-full" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+            <input className="border p-1 w-full" placeholder="Пароль" type="password" value={password} onChange={e => setPassword(e.target.value)} />
+            <div className="space-x-2">
+              <button className="bg-blue-500 text-white px-3 py-1" onClick={login}>Войти</button>
+              <button className="text-sm" onClick={() => setShowReg(true)}>Регистрация</button>
+            </div>
+          </div>
+        );
+      }
+
+      return (
+        <div>
+          <div className="flex justify-between items-center mb-4">
+            <h1 className="text-xl font-bold">Мероприятия</h1>
+            <button className="text-sm text-blue-600" onClick={logout}>Выйти</button>
+          </div>
+          <ul>
+            {events.map(e => (
+              <li key={e.id} className="mb-2 border p-2 rounded">
+                <div className="font-semibold">{e.title}</div>
+                <div className="text-sm text-gray-600">{e.datetime}</div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      );
+    }
+
+    ReactDOM.render(<App />, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "molpalata",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- expand README with setup instructions in Russian
- add default points mapping for event categories
- implement registration form on the frontend
- create tests for event creation with automatic points

## Testing
- `python3 -m unittest discover -s backend_py/tests -v`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f178425c8332b5a5583212b83e6a